### PR TITLE
CG-11483 remove line brakes in bulk content on Linux

### DIFF
--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
@@ -100,7 +100,7 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
 
                 itemJson += $"{{ \"index\": {{ \"_id\": \"{id}\", \"language_routing\": \"{language}\" }} }}";
                 itemJson += Environment.NewLine;
-                itemJson += JsonSerializer.Serialize(item, serializeOptions).Replace("\r\n", "");
+                itemJson += JsonSerializer.Serialize(item, serializeOptions).Replace("\r\n", "").Replace("\n", "");
                 itemJson += Environment.NewLine;
             }
 


### PR DESCRIPTION
**Fix:** Ensure new lines are stripped on both Windows (`\r\n`) and Linux (`\n`) so that bulk content is consistently formatted across all platforms.