### PR TITLE
CG-14843: Content Sync Language Always Set to En

### DIFF
--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Sample/Program.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Sample/Program.cs
@@ -192,7 +192,7 @@ var exampleDataInstance3 = new Cafe
     }
 };
 
-await client.SaveContentAsync(generateId: (x) => $"{x.Name}_{x.Address.City}", exampleDataInstance1, exampleDataInstance2, exampleDataInstance3);
+await client.SaveContentAsync(generateId: (x) => $"{x.Name}_{x.Address.City}", "en", exampleDataInstance1, exampleDataInstance2, exampleDataInstance3);
 #endregion
 
 #region ExampleTypes

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
@@ -206,7 +206,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             mockRestClient.Setup(c => c.HandleResponse(response));
 
             // Act
-            await repository.SaveContentAsync(generateId: (x) => x.ToString(), exampleData);
+            await repository.SaveContentAsync(generateId: (x) => x.ToString(), "en", exampleData);
 
             // Assert
             mockRestClient.Verify(c => c.SendAsync(It.Is<HttpRequestMessage>(x => Compare(request, x))), Times.Once);
@@ -316,7 +316,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             mockRestClient.Setup(c => c.HandleResponse(response));
 
             // Act
-            await repository.SaveContentAsync<object>(generateId, locationStockholm, locationLondon, event1, event2, event3);
+            await repository.SaveContentAsync<object>(generateId, "en", locationStockholm, locationLondon, event1, event2, event3);
 
             // Assert
             Assert.AreEqual(expectedJsonString, jsonString);
@@ -353,7 +353,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             };
 
             // Act
-            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), exampleData);
+            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), "en", exampleData);
             var result = createdContent.ReadAsStringAsync().Result;
 
             // Assert
@@ -387,7 +387,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             };
 
             // Act
-            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), exampleData);
+            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), "en", exampleData);
             var result = createdContent.ReadAsStringAsync().Result;
 
             // Assert

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/GraphSourceClient.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/GraphSourceClient.cs
@@ -89,10 +89,10 @@ namespace Optimizely.Graph.Source.Sdk
         /// <param name="generateId">Id associated with content.</param>
         /// <param name="data">Dynamic data being saved to Content Graph.</param>
         /// <returns></returns>
-        public async Task<string> SaveContentAsync<T>(Func<T, string> generateId, params T[] data)
+        public async Task<string> SaveContentAsync<T>(Func<T, string> generateId, string language, params T[] data)
             where T : class, new()
         {
-            return await repository.SaveContentAsync(generateId, data);
+            return await repository.SaveContentAsync(generateId, language, data);
         }
 
         /// <summary>

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
@@ -80,10 +80,10 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
         }
 
         /// <inheritdoc/>
-        public async Task<string> SaveContentAsync<T>(Func<T, string> generateId, params T[] data)
+        public async Task<string> SaveContentAsync<T>(Func<T, string> generateId, string language, params T[] data)
             where T : class, new()
         {
-            var content = CreateContent(generateId, data);
+            var content = CreateContent(generateId, language, data);
 
             using (var requestMessage = new HttpRequestMessage(HttpMethod.Post, $"{DataUrl}?id={source}"))
             {
@@ -96,7 +96,7 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
             return string.Empty;
         }
 
-        public StringContent CreateContent<T>(Func<T, string> generateId, params T[] data)
+        public StringContent CreateContent<T>(Func<T, string> generateId, string language, params T[] data)
         {
             var serializeOptions = new JsonSerializerOptions
             {
@@ -111,7 +111,6 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
             foreach (var item in data)
             {
                 var id = generateId(item);
-                var language = "en";
 
                 itemJson += $"{{\"index\":{{\"_id\":\"{id}\",\"language_routing\":\"{language}\"}}}}";
                 itemJson += Environment.NewLine;

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/IGraphSourceRepository.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/IGraphSourceRepository.cs
@@ -40,7 +40,7 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
         /// <param name="generateId">Id associated with content.</param>
         /// <param name="data">Dynamic data being saved to Content Graph.</param>
         /// <returns></returns>
-        Task<string> SaveContentAsync<T>(Func<T, string> generateId, params T[] data) where T : class, new();
+        Task<string> SaveContentAsync<T>(Func<T, string> generateId, string language, params T[] data) where T : class, new();
 
         /// <summary>
         /// Removes content previously stored by source.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ You can find more information https://docs.developers.optimizely.com/platform-op
 
 You can use the client by calling `Create()` and providing your base url, Content Graph source, application key and secret, then calling one of the provided functions for synchronizing Content Types and Content Data.
 
+#### Sync Content Types
 ```csharp
 // Initialize the GraphSourceClient by calling the Create method
 var client = GraphSourceClient.Create(new Uri("https://cg.optimizely.com"), "", "", "");
@@ -55,6 +56,26 @@ client.ConfigurePropertyType<ExampleClassObject.SubType1>()
 
 // Save content types to Optimizely Graph
 var result = await graphSourceClient.SaveTypesAsync();
+```
+
+#### Sync Content
+```csharp
+// Instantiate custom C# object and assign values
+var exampleData = new ExampleClassObject
+{
+    FirstName = "First",
+    LastName = "Last",
+    Age = 30,
+    SubType = new SubType1
+    {
+        One = "One",
+        Two = 2,
+    }
+};
+
+// Use the client to sync content
+// Parameters are generated id, language, and data object
+await client.SaveContentAsync(generateId: (x) => $"{x.FirstName}_{x.LastName}", "en", exampleData);
 ```
 
 ## Run Examples


### PR DESCRIPTION
# CG-14843: Content Sync Language Always Set to En

In graph-source-sdk, content is always routed to English when synced. This seems to be hard coded ([see code here](https://github.com/episerver/graph-source-sdk/blob/main/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs#L114))