### PR TITLE
CG-14844: Graph Source SDK - Journal Id Not Returned

### DIFF
--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
@@ -203,14 +203,14 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             var request = new HttpRequestMessage(HttpMethod.Post, $"/api/content/v2/data?id={source}") { Content = content };
 
             mockRestClient.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>())).ReturnsAsync(response);
-            mockRestClient.Setup(c => c.HandleResponse<ApiResponse>(response));
+            mockRestClient.Setup(c => c.HandleResponse<ContentV2ApiResponse>(response));
 
             // Act
             await repository.SaveContentAsync(generateId: (x) => x.ToString(), exampleData);
 
             // Assert
             mockRestClient.Verify(c => c.SendAsync(It.Is<HttpRequestMessage>(x => Compare(request, x))), Times.Once);
-            mockRestClient.Verify(c => c.HandleResponse<ApiResponse>(response), Times.Once);
+            mockRestClient.Verify(c => c.HandleResponse<ContentV2ApiResponse>(response), Times.Once);
             mockRestClient.VerifyAll();
         }
         
@@ -247,10 +247,10 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             var response = new HttpResponseMessage(HttpStatusCode.OK);
             var request = new HttpRequestMessage(HttpMethod.Post, $"/api/content/v2/data?id={source}") { Content = content };
 
-            var expectedApiResponse = new ApiResponse { JournalId = "stream/id" };
+            var expectedApiResponse = new ContentV2ApiResponse { JournalId = "stream/id" };
 
             mockRestClient.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>())).ReturnsAsync(response);
-            mockRestClient.Setup(c => c.HandleResponse<ApiResponse>(response)).ReturnsAsync(expectedApiResponse);
+            mockRestClient.Setup(c => c.HandleResponse<ContentV2ApiResponse>(response)).ReturnsAsync(expectedApiResponse);
 
             // Act
             var actualJournalId = await repository.SaveContentAsync(generateId: (x) => x.ToString(), exampleData);
@@ -258,7 +258,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             // Assert
             Assert.AreEqual(expectedApiResponse.JournalId, actualJournalId);
             mockRestClient.Verify(c => c.SendAsync(It.Is<HttpRequestMessage>(x => Compare(request, x))), Times.Once);
-            mockRestClient.Verify(c => c.HandleResponse<ApiResponse>(response), Times.Once);
+            mockRestClient.Verify(c => c.HandleResponse<ContentV2ApiResponse>(response), Times.Once);
             mockRestClient.VerifyAll();
         }
 
@@ -361,7 +361,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             var request = new HttpRequestMessage(HttpMethod.Post, $"/api/content/v2/data?id={source}") { Content = content };
 
             mockRestClient.Setup(c => c.SendAsync(It.IsAny<HttpRequestMessage>())).ReturnsAsync(response);
-            mockRestClient.Setup(c => c.HandleResponse<ApiResponse>(response));
+            mockRestClient.Setup(c => c.HandleResponse<ContentV2ApiResponse>(response));
 
             // Act
             await repository.SaveContentAsync<object>(generateId, locationStockholm, locationLondon, event1, event2, event3);
@@ -370,7 +370,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             Assert.AreEqual(expectedJsonString, jsonString);
 
             mockRestClient.Verify(c => c.SendAsync(It.Is<HttpRequestMessage>(x => Compare(request, x))), Times.Once);
-            mockRestClient.Verify(c => c.HandleResponse<ApiResponse>(response), Times.Once);
+            mockRestClient.Verify(c => c.HandleResponse<ContentV2ApiResponse>(response), Times.Once);
             mockRestClient.VerifyAll();
         }
 

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
@@ -88,7 +88,7 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
             using var requestMessage = new HttpRequestMessage(HttpMethod.Post, $"{DataUrl}?id={source}");
             requestMessage.Content = content;
             using var responseMessage = await client.SendAsync(requestMessage);
-            var response = await client.HandleResponse<ApiResponse>(responseMessage);
+            var response = await client.HandleResponse<ContentV2ApiResponse>(responseMessage);
             return response?.JournalId ?? string.Empty;
         }
 

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/Models/ContentV2ApiResponse.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/Models/ContentV2ApiResponse.cs
@@ -1,4 +1,4 @@
-public class ApiResponse
+public class ContentV2ApiResponse
 {
         public string JournalId { get; set; }
 }


### PR DESCRIPTION
# CG-14844: Graph Source SDK - Journal Id Not Returned

When something is synced in graph-source-sdk, the content will go through _stream. To be able to know the status for the synced content, we would need to be able to see the return from the service, but this is not happening in [SaveContentAsync](https://github.com/episerver/graph-source-sdk/blob/main/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs#L96).

The response body looks like this:
<img width="576" height="85" alt="image" src="https://github.com/user-attachments/assets/859006f3-8436-4ccf-b930-4c9d7301c0ba" />

With the information, a developer would be able to see why sync is failing by hitting this path (while being authenticated).