### PR TITLE
Fix language support

### DIFF
--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
@@ -520,8 +520,11 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             Assert.AreEqual("", lines[2], "Expected empty line to be empty.");
         }
         
-        [TestMethod]
-        public async Task CreateContent_ShouldSetLanguageRoutingAndLanguageName()
+        [DataTestMethod]
+        [DataRow("sv")]
+        [DataRow("nl")]
+        [DataRow("en")]
+        public async Task CreateContent_ShouldSetLanguageRoutingAndLanguageName(string language)
         {
             // Arrange
             repository.ConfigureContentType<ExampleClassObject>()
@@ -547,13 +550,13 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
             };
 
             // Act
-            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), "sv", exampleData);
+            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), language, exampleData);
             var result = createdContent.ReadAsStringAsync().Result;
 
             // Assert
             var lines = result.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
-            Assert.AreEqual("""{"index":{"_id":"Optimizely.Graph.Source.Sdk.Tests.ExampleObjects.ExampleClassObject","language_routing":"sv"}}""", lines[0], "Expected index line to contain language_routing 'sv'.");
-            Assert.AreEqual("""{"Status$$String":"Published","__typename":"ExampleClassObject","_rbac":"r:Everyone:Read","ContentType$$String":["ExampleClassObject"],"Language":{"Name$$String":"sv"},"FirstName$$String___searchable":"First","LastName$$String___searchable":"Last","Age$$Int":99,"SubType":{"One$$String___searchable":"type one","Two$$Int":13}}""", lines[1], "Expected content line to contain Language.Name$$String 'sv'.");
+            Assert.AreEqual($@"{{""index"":{{""_id"":""Optimizely.Graph.Source.Sdk.Tests.ExampleObjects.ExampleClassObject"",""language_routing"":""{language}""}}}}", lines[0], $"Expected index line to contain language_routing '{language}'.");
+            Assert.AreEqual($@"{{""Status$$String"":""Published"",""__typename"":""ExampleClassObject"",""_rbac"":""r:Everyone:Read"",""ContentType$$String"":[""ExampleClassObject""],""Language"":{{""Name$$String"":""{language}""}},""FirstName$$String___searchable"":""First"",""LastName$$String___searchable"":""Last"",""Age$$Int"":99,""SubType"":{{""One$$String___searchable"":""type one"",""Two$$Int"":13}}}}", lines[1], $"Expected content line to contain Language.Name$$String '{language}'.");
         }
 
         [TestMethod]

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.Tests/RepositoryTests/GraphSourceRepositoryTests.cs
@@ -521,6 +521,42 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
         }
         
         [TestMethod]
+        public async Task CreateContent_ShouldSetLanguageRoutingAndLanguageName()
+        {
+            // Arrange
+            repository.ConfigureContentType<ExampleClassObject>()
+               .Field(x => x.FirstName, IndexingType.Searchable)
+               .Field(x => x.LastName, IndexingType.Searchable)
+               .Field(x => x.Age, IndexingType.Queryable)
+               .Field(x => x.SubType, IndexingType.PropertyType);
+
+            repository.ConfigurePropertyType<ExampleClassObject.SubType1>()
+                .Field(x => x.One, IndexingType.Searchable)
+                .Field(x => x.Two, IndexingType.Queryable);
+
+            var exampleData = new ExampleClassObject
+            {
+                FirstName = "First",
+                LastName = "Last",
+                Age = 99,
+                SubType = new ExampleClassObject.SubType1
+                {
+                    One = "type one",
+                    Two = 13
+                }
+            };
+
+            // Act
+            var createdContent = repository.CreateContent(generateId: (x) => x.ToString(), "sv", exampleData);
+            var result = createdContent.ReadAsStringAsync().Result;
+
+            // Assert
+            var lines = result.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+            Assert.AreEqual("""{"index":{"_id":"Optimizely.Graph.Source.Sdk.Tests.ExampleObjects.ExampleClassObject","language_routing":"sv"}}""", lines[0], "Expected index line to contain language_routing 'sv'.");
+            Assert.AreEqual("""{"Status$$String":"Published","__typename":"ExampleClassObject","_rbac":"r:Everyone:Read","ContentType$$String":["ExampleClassObject"],"Language":{"Name$$String":"sv"},"FirstName$$String___searchable":"First","LastName$$String___searchable":"Last","Age$$Int":99,"SubType":{"One$$String___searchable":"type one","Two$$Int":13}}""", lines[1], "Expected content line to contain Language.Name$$String 'sv'.");
+        }
+
+        [TestMethod]
         public async Task DeleteContentAsync_ThrowsNotImplementedException()
         {
             var response = new HttpResponseMessage(HttpStatusCode.OK);
@@ -603,12 +639,17 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
 
         private string BuildExpectedContentJsonString<T>(Func<T, string> generateId, params T[] items)
         {
+            return BuildExpectedContentJsonString(generateId, "en", items);
+        }
+
+        private string BuildExpectedContentJsonString<T>(Func<T, string> generateId, string language, params T[] items)
+        {
             var serializeOptions = new JsonSerializerOptions
             {
                 WriteIndented = false,
                 Converters =
                 {
-                    new SourceSdkContentConverter()
+                    new SourceSdkContentConverter(language)
                 }
             };
 
@@ -616,7 +657,7 @@ namespace Optimizely.Graph.Source.Sdk.Tests.RepositoryTests
 
             foreach (var data in items)
             {
-                itemJson += $"{{\"index\":{{\"_id\":\"{generateId(data)}\",\"language_routing\":\"en\"}}}}";
+                itemJson += $"{{\"index\":{{\"_id\":\"{generateId(data)}\",\"language_routing\":\"{language}\"}}}}";
                 itemJson += Environment.NewLine;
                 itemJson += JsonSerializer.Serialize(data, serializeOptions);
                 itemJson += Environment.NewLine;

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/JsonConverters/SourceSdkContentConverter.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/JsonConverters/SourceSdkContentConverter.cs
@@ -6,6 +6,13 @@ namespace Optimizely.Graph.Source.Sdk.JsonConverters
 {
     public class SourceSdkContentConverter : JsonConverter<object>
     {
+        private readonly string language;
+
+        public SourceSdkContentConverter(string language)
+        {
+            this.language = language;
+        }
+
         public override bool CanConvert(Type typeToConvert)
         {
             return typeToConvert.GetType() != typeof(IEnumerable<TypeFieldConfiguration>);
@@ -32,7 +39,7 @@ namespace Optimizely.Graph.Source.Sdk.JsonConverters
             writer.WriteStartObject("index");
 
             writer.WriteString("_id", "testar"); // TODO: Set Id
-            writer.WriteString("language_routing", "en"); // TODO: Set Language
+            writer.WriteString("language_routing", language); // TODO: Set Language
 
             writer.WriteEndObject();
             writer.WriteEndObject();
@@ -55,7 +62,7 @@ namespace Optimizely.Graph.Source.Sdk.JsonConverters
             writer.WriteEndArray();
 
             writer.WriteStartObject("Language");
-            writer.WriteString("Name$$String", "en"); //TODO: Set Language
+            writer.WriteString("Name$$String", language);
             writer.WriteEndObject();
 
             foreach(var fieldInfoItem in fieldInfoItems)

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/JsonConverters/SourceSdkContentConverter.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/JsonConverters/SourceSdkContentConverter.cs
@@ -39,7 +39,7 @@ namespace Optimizely.Graph.Source.Sdk.JsonConverters
             writer.WriteStartObject("index");
 
             writer.WriteString("_id", "testar"); // TODO: Set Id
-            writer.WriteString("language_routing", language); // TODO: Set Language
+            writer.WriteString("language_routing", language);
 
             writer.WriteEndObject();
             writer.WriteEndObject();

--- a/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
+++ b/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Repositories/GraphSourceRepository.cs
@@ -4,7 +4,6 @@ using Optimizely.Graph.Source.Sdk.SourceConfiguration;
 using System.Linq.Expressions;
 using System.Text;
 using System.Text.Json;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Optimizely.Graph.Source.Sdk.Repositories
 {
@@ -128,7 +127,7 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
                 WriteIndented = false,
                 Converters =
                 {
-                    new SourceSdkContentConverter()
+                    new SourceSdkContentConverter(language)
                 }
             };
             
@@ -172,7 +171,7 @@ namespace Optimizely.Graph.Source.Sdk.Repositories
                 WriteIndented = false,
                 Converters =
                 {
-                    new SourceSdkContentConverter()
+                    new SourceSdkContentConverter(language)
                 }
             };
 


### PR DESCRIPTION
Fixes #24

Ensures that the `Language.Name` is set as a part of a request, was previously hard-coded to "en" with:

> //TODO: Set Language

This PR maps the value through to the `SourceSdkContentConverter` and sets the language as well as introducing a unit test (and fixing other ones).