### PR TITLE
Fix YAML indentation in nuget-publish workflow

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -36,7 +36,7 @@ jobs:
       run: dotnet pack ./Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk.csproj --configuration Release -p:PackageVersion=${{ steps.semver.outputs.version }}
     - name: Publish to Episerver
       run: dotnet nuget push ./Optimizely.Graph.Source.Sdk/Optimizely.Graph.Source.Sdk/bin/Release/Optimizely.Graph.Source.Sdk.${{ steps.semver.outputs.version }}.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source https://nuget.pkg.github.com/episerver/index.json
-      - name: Upload Artifact
+    - name: Upload Artifact
       uses: actions/upload-artifact@v4
       with:
         name: Optimizely.Graph.Source.Sdk.${{ steps.semver.outputs.version }}


### PR DESCRIPTION
## Summary
- Fix YAML syntax error on line 39 of `nuget-publish.yml` that has been breaking every push to `main`
- The `Upload Artifact` step was indented 6 spaces (under `run:`) instead of 4 spaces (as a sibling step), causing an invalid YAML parse error

## Test plan
- [ ] Verify the workflow file passes GitHub Actions YAML validation on push
- [ ] Trigger the workflow manually via `workflow_dispatch` to confirm it runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)